### PR TITLE
add expo-passkey plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,58 +13,60 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 
 ## Adapters
 
-| Name      | Description                       | Link                                                                                                 |
-| --------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `convex`  | Convex adapter for BetterAuth     | [Link](https://www.better-auth-kit.com/docs/adapters/convex)                                         |
-| `surreal` | SurrealDB adapter for BetterAuth  | [Link](https://github.com/oskar-gmerek/surreal-better-auth/)                                         |
+| Name | Description | Link |
+|------|-------------|------|
+| `convex` | Convex adapter for BetterAuth | [Link](https://www.better-auth-kit.com/docs/adapters/convex) |
+| `surreal` | SurrealDB adapter for BetterAuth | [Link](https://github.com/oskar-gmerek/surreal-better-auth/) |
 | `payload` | PayloadCMS adapter for BetterAuth | [Link](https://github.com/ForrestDevs/payload-better-auth/tree/main/packages/better-auth-db-adapter) |
+| `typeorm` | TypeORM adapter for BetterAuth | [Link](https://github.com/Zastinian/better-auth-typeorm) |
 
 ## Plugins
 
-| Name                     | Description                                                                                                                    | Link                                                               |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| `reverify`               | Prompt the user to re-verify their identity by providing a form of authentication for revalidation                             | [Link](https://www.better-auth-kit.com/docs/plugins/reverify)      |
-| `legal-consent`          | A Legal Consent plugin for BetterAuth                                                                                          | [Link](https://www.better-auth-kit.com/docs/plugins/legal-consent) |
-| `@better-auth-kit/tests` | A collection of utilities to help you test your Better-Auth plugins                                                            | [Link](https://www.better-auth-kit.com/docs/libraries/tests)       |
-| `seed`                   | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database                          | [Link](https://www.better-auth-kit.com/docs/cli/seed)              |
-| `polar`                  | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow                            | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth)   |
-| `expo-passkey`           | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey)                    |
+| Name | Description | Link |
+|------|-------------|------|
+| `reverify` | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://www.better-auth-kit.com/docs/plugins/reverify) |
+| `legal-consent` | A Legal Consent plugin for BetterAuth | [Link](https://www.better-auth-kit.com/docs/plugins/legal-consent) |
+| `@better-auth-kit/tests` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://www.better-auth-kit.com/docs/libraries/tests) |
+| `seed` | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://www.better-auth-kit.com/docs/cli/seed) |
+| `polar` | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth) |
+| `expo-passkey` | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey) |
 
 ## Projects (Open Source, >1k stars)
 
-| Name               | Description                                                                                            | Link                                                      |
-| ------------------ | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
-| `Follow`           | 🧡 Follow everything in one place                                                                      | [Link](https://github.com/RSSNext/Follow)                 |
-| `Dokploy`          | Open Source Alternative to Vercel, Netlify and Heroku                                                  | [Link](https://github.com/Dokploy/dokploy)                |
-| `Open Alternative` | A community driven list of open source alternatives to proprietary software and applications           | [Link](https://github.com/piotrkulpinski/openalternative) |
-| `One`              | ❶ One is a new React framework - target web and native with a single Vite plugin and fully shared code | [Link](https://github.com/onejs/one)                      |
-| `Mail0`            | The first open source email app that puts your privacy and safety first                                | [Link](https://github.com/Mail-0/Mail-0)                  |
-| `Shiro`            | 📜 A minimalist personal website embodying the purity of paper and freshness of snow.                  | [Link](https://github.com/Innei/Shiro)                    |
+| Name | Description | Link |
+|------|-------------|------|
+| `Follow` | 🧡 Follow everything in one place | [Link](https://github.com/RSSNext/Follow) |
+| `Dokploy` | Open Source Alternative to Vercel, Netlify and Heroku | [Link](https://github.com/Dokploy/dokploy) |
+| `Open Alternative` | A community driven list of open source alternatives to proprietary software and applications | [Link](https://github.com/piotrkulpinski/openalternative) |
+| `One` | ❶ One is a new React framework - target web and native with a single Vite plugin and fully shared code | [Link](https://github.com/onejs/one) |
+| `Mail0` | The first open source email app that puts your privacy and safety first| [Link](https://github.com/Mail-0/Mail-0) |
+| `Shiro` | 📜 A minimalist personal website embodying the purity of paper and freshness of snow.| [Link](https://github.com/Innei/Shiro) |
 
 ## Starter Kits
 
-| Name                                     | Description                                                                                                                              | Link                                                                           |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `next-js-starter`                        | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query                                              | [Link](https://github.com/daveyplate/better-auth-nextjs-starter)               |
-| `tanstack-starter`                       | Better Auth TanStack starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query                                             | [Link](https://github.com/daveyplate/better-auth-tanstack-starter)             |
-| `next-js-starter`                        | A feature rich Next.js starter template by yared yilma                                                                                   | [Link](https://github.com/yaredow/next-starter)                                |
-| `better-auth-react-router-cloudflare-d1` | Example of Better Auth integrated with React Router (v7) which is setup to deploy to Cloudflare & use D1 for the database                | [Link](https://github.com/matthewlynch/better-auth-react-router-cloudflare-d1) |
-| `svelter-auth`                           | A sveltekit betterauth starter template by robimez                                                                                       | [Link](https://github.com/robimez/svelter-auth)                                |
-| `supastarter`                            | The scalable and production-ready Next.js SaaS starter kit                                                                               | [Link](https://github.com/supabase/supastarter)                                |
-| `boring-template`                        | Not your average SaaS boilerplate                                                                                                        | [Link](https://www.boringtemplate.com/)                                        |
-| `pro-stack`                              | Ship your startup in minutes with ProStack                                                                                               | [Link](https://pro-stack.vercel.app/)                                          |
-| `create-better-t-stack`                  | A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations           | [Link](https://github.com/better-t-stack/create-better-t-stack)                |
-| `next-js-pages-starter`                  | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query by davey plate                               | [Link](https://github.com/daveyplate/better-auth-nextjs-pages-starter)         |
-| `railway-template`                       | Better Auth Railway template                                                                                                             | [Link](https://railway.com/template/VOQsdL)                                    |
-| `zap-ts`                                 | The boilerplate to build applications as fast as a zap.                                                                                  | [Link](https://zap-ts.alexandretrotel.org)                                     |
-| `better-next`                            | Add `better-auth` using a 🔥 single command 🔥 or use the template itself, built with Next.js, PostgreSQL, Drizzle, shadcn/ui + Registry | [Link](https://github.com/nrjdalal/better-next)                                |
-| `Hono x Better Auth`                     | 🚀 Seamlessly integrate powerful authentication with Hono, Better-Auth and Drizzle ORM. 🛡️✨                                             | [Link](https://github.com/LovelessCodes/hono-better-auth)                      |
+| Name | Description | Link |
+|------|-------------|------|
+| `next-js-starter` | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query | [Link](https://github.com/daveyplate/better-auth-nextjs-starter) |
+| `tanstack-starter` | Better Auth TanStack starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query | [Link](https://github.com/daveyplate/better-auth-tanstack-starter) |
+| `next-js-starter` | A feature rich Next.js starter template by yared yilma | [Link](https://github.com/yaredow/next-starter) |
+| `better-auth-react-router-cloudflare-d1` | Example of Better Auth integrated with React Router (v7) which is setup to deploy to Cloudflare & use D1 for the database | [Link](https://github.com/matthewlynch/better-auth-react-router-cloudflare-d1) |
+| `svelter-auth` | A sveltekit betterauth starter template by robimez | [Link](https://github.com/robimez/svelter-auth) |
+| `supastarter` | The scalable and production-ready Next.js SaaS starter kit | [Link](https://github.com/supabase/supastarter) |
+| `boring-template` | Not your average SaaS boilerplate | [Link](https://www.boringtemplate.com/) |
+| `pro-stack` | Ship your startup in minutes with ProStack| [Link](https://pro-stack.vercel.app/) |
+| `create-better-t-stack` | A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations | [Link](https://github.com/better-t-stack/create-better-t-stack) |
+| `next-js-pages-starter` | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query by davey plate | [Link](https://github.com/daveyplate/better-auth-nextjs-pages-starter) |
+| `railway-template` | Better Auth Railway template | [Link](https://railway.com/template/VOQsdL) |
+| `zap-ts` | The boilerplate to build applications as fast as a zap. | [Link](https://zap-ts.alexandretrotel.org) |
+| `better-next` | Add `better-auth` using a 🔥 single command 🔥 or use the template itself, built with Next.js, PostgreSQL, Drizzle, shadcn/ui + Registry | [Link](https://github.com/nrjdalal/better-next) |
+| `Hono x Better Auth` | 🚀 Seamlessly integrate powerful authentication with Hono, Better-Auth and Drizzle ORM. 🛡️✨ | [Link](https://github.com/LovelessCodes/hono-better-auth) |
 
 ## UI
 
-| Name             | Description                                           | Link                                                 |
-| ---------------- | ----------------------------------------------------- | ---------------------------------------------------- |
+| Name | Description | Link |
+|------|-------------|------|
 | `better-auth-ui` | Plug & play shadcn/ui auth components for better-auth | [Link](https://github.com/daveyplate/better-auth-ui) |
+
 
 ## Contributing
 
@@ -73,3 +75,4 @@ Open a PR to add to the list.
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -13,58 +13,58 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 
 ## Adapters
 
-| Name | Description | Link |
-|------|-------------|------|
-| `convex` | Convex adapter for BetterAuth | [Link](https://www.better-auth-kit.com/docs/adapters/convex) |
-| `surreal` | SurrealDB adapter for BetterAuth | [Link](https://github.com/oskar-gmerek/surreal-better-auth/) |
+| Name      | Description                       | Link                                                                                                 |
+| --------- | --------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `convex`  | Convex adapter for BetterAuth     | [Link](https://www.better-auth-kit.com/docs/adapters/convex)                                         |
+| `surreal` | SurrealDB adapter for BetterAuth  | [Link](https://github.com/oskar-gmerek/surreal-better-auth/)                                         |
 | `payload` | PayloadCMS adapter for BetterAuth | [Link](https://github.com/ForrestDevs/payload-better-auth/tree/main/packages/better-auth-db-adapter) |
 
 ## Plugins
 
-| Name | Description | Link |
-|------|-------------|------|
-| `reverify` | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://www.better-auth-kit.com/docs/plugins/reverify) |
-| `legal-consent` | A Legal Consent plugin for BetterAuth | [Link](https://www.better-auth-kit.com/docs/plugins/legal-consent) |
-| `@better-auth-kit/tests` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://www.better-auth-kit.com/docs/libraries/tests) |
-| `seed` | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://www.better-auth-kit.com/docs/cli/seed) |
-| `polar` | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth) |
+| Name                     | Description                                                                                                                    | Link                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `reverify`               | Prompt the user to re-verify their identity by providing a form of authentication for revalidation                             | [Link](https://www.better-auth-kit.com/docs/plugins/reverify)      |
+| `legal-consent`          | A Legal Consent plugin for BetterAuth                                                                                          | [Link](https://www.better-auth-kit.com/docs/plugins/legal-consent) |
+| `@better-auth-kit/tests` | A collection of utilities to help you test your Better-Auth plugins                                                            | [Link](https://www.better-auth-kit.com/docs/libraries/tests)       |
+| `seed`                   | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database                          | [Link](https://www.better-auth-kit.com/docs/cli/seed)              |
+| `polar`                  | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow                            | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth)   |
+| `expo-passkey`           | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey)                    |
 
 ## Projects (Open Source, >1k stars)
 
-| Name | Description | Link |
-|------|-------------|------|
-| `Follow` | 🧡 Follow everything in one place | [Link](https://github.com/RSSNext/Follow) |
-| `Dokploy` | Open Source Alternative to Vercel, Netlify and Heroku | [Link](https://github.com/Dokploy/dokploy) |
-| `Open Alternative` | A community driven list of open source alternatives to proprietary software and applications | [Link](https://github.com/piotrkulpinski/openalternative) |
-| `One` | ❶ One is a new React framework - target web and native with a single Vite plugin and fully shared code | [Link](https://github.com/onejs/one) |
-| `Mail0` | The first open source email app that puts your privacy and safety first| [Link](https://github.com/Mail-0/Mail-0) |
-| `Shiro` | 📜 A minimalist personal website embodying the purity of paper and freshness of snow.| [Link](https://github.com/Innei/Shiro) |
+| Name               | Description                                                                                            | Link                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| `Follow`           | 🧡 Follow everything in one place                                                                      | [Link](https://github.com/RSSNext/Follow)                 |
+| `Dokploy`          | Open Source Alternative to Vercel, Netlify and Heroku                                                  | [Link](https://github.com/Dokploy/dokploy)                |
+| `Open Alternative` | A community driven list of open source alternatives to proprietary software and applications           | [Link](https://github.com/piotrkulpinski/openalternative) |
+| `One`              | ❶ One is a new React framework - target web and native with a single Vite plugin and fully shared code | [Link](https://github.com/onejs/one)                      |
+| `Mail0`            | The first open source email app that puts your privacy and safety first                                | [Link](https://github.com/Mail-0/Mail-0)                  |
+| `Shiro`            | 📜 A minimalist personal website embodying the purity of paper and freshness of snow.                  | [Link](https://github.com/Innei/Shiro)                    |
 
 ## Starter Kits
 
-| Name | Description | Link |
-|------|-------------|------|
-| `next-js-starter` | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query | [Link](https://github.com/daveyplate/better-auth-nextjs-starter) |
-| `tanstack-starter` | Better Auth TanStack starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query | [Link](https://github.com/daveyplate/better-auth-tanstack-starter) |
-| `next-js-starter` | A feature rich Next.js starter template by yared yilma | [Link](https://github.com/yaredow/next-starter) |
-| `better-auth-react-router-cloudflare-d1` | Example of Better Auth integrated with React Router (v7) which is setup to deploy to Cloudflare & use D1 for the database | [Link](https://github.com/matthewlynch/better-auth-react-router-cloudflare-d1) |
-| `svelter-auth` | A sveltekit betterauth starter template by robimez | [Link](https://github.com/robimez/svelter-auth) |
-| `supastarter` | The scalable and production-ready Next.js SaaS starter kit | [Link](https://github.com/supabase/supastarter) |
-| `boring-template` | Not your average SaaS boilerplate | [Link](https://www.boringtemplate.com/) |
-| `pro-stack` | Ship your startup in minutes with ProStack| [Link](https://pro-stack.vercel.app/) |
-| `create-better-t-stack` | A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations | [Link](https://github.com/better-t-stack/create-better-t-stack) |
-| `next-js-pages-starter` | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query by davey plate | [Link](https://github.com/daveyplate/better-auth-nextjs-pages-starter) |
-| `railway-template` | Better Auth Railway template | [Link](https://railway.com/template/VOQsdL) |
-| `zap-ts` | The boilerplate to build applications as fast as a zap. | [Link](https://zap-ts.alexandretrotel.org) |
-| `better-next` | Add `better-auth` using a 🔥 single command 🔥 or use the template itself, built with Next.js, PostgreSQL, Drizzle, shadcn/ui + Registry | [Link](https://github.com/nrjdalal/better-next) |
-| `Hono x Better Auth` | 🚀 Seamlessly integrate powerful authentication with Hono, Better-Auth and Drizzle ORM. 🛡️✨ | [Link](https://github.com/LovelessCodes/hono-better-auth) |
+| Name                                     | Description                                                                                                                              | Link                                                                           |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `next-js-starter`                        | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query                                              | [Link](https://github.com/daveyplate/better-auth-nextjs-starter)               |
+| `tanstack-starter`                       | Better Auth TanStack starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query                                             | [Link](https://github.com/daveyplate/better-auth-tanstack-starter)             |
+| `next-js-starter`                        | A feature rich Next.js starter template by yared yilma                                                                                   | [Link](https://github.com/yaredow/next-starter)                                |
+| `better-auth-react-router-cloudflare-d1` | Example of Better Auth integrated with React Router (v7) which is setup to deploy to Cloudflare & use D1 for the database                | [Link](https://github.com/matthewlynch/better-auth-react-router-cloudflare-d1) |
+| `svelter-auth`                           | A sveltekit betterauth starter template by robimez                                                                                       | [Link](https://github.com/robimez/svelter-auth)                                |
+| `supastarter`                            | The scalable and production-ready Next.js SaaS starter kit                                                                               | [Link](https://github.com/supabase/supastarter)                                |
+| `boring-template`                        | Not your average SaaS boilerplate                                                                                                        | [Link](https://www.boringtemplate.com/)                                        |
+| `pro-stack`                              | Ship your startup in minutes with ProStack                                                                                               | [Link](https://pro-stack.vercel.app/)                                          |
+| `create-better-t-stack`                  | A modern CLI tool for scaffolding end-to-end type-safe TypeScript projects with best practices and customizable configurations           | [Link](https://github.com/better-t-stack/create-better-t-stack)                |
+| `next-js-pages-starter`                  | Better Auth Next.js starter template with PostgreSQL, Drizzle, shadcn/ui and TanStack Query by davey plate                               | [Link](https://github.com/daveyplate/better-auth-nextjs-pages-starter)         |
+| `railway-template`                       | Better Auth Railway template                                                                                                             | [Link](https://railway.com/template/VOQsdL)                                    |
+| `zap-ts`                                 | The boilerplate to build applications as fast as a zap.                                                                                  | [Link](https://zap-ts.alexandretrotel.org)                                     |
+| `better-next`                            | Add `better-auth` using a 🔥 single command 🔥 or use the template itself, built with Next.js, PostgreSQL, Drizzle, shadcn/ui + Registry | [Link](https://github.com/nrjdalal/better-next)                                |
+| `Hono x Better Auth`                     | 🚀 Seamlessly integrate powerful authentication with Hono, Better-Auth and Drizzle ORM. 🛡️✨                                             | [Link](https://github.com/LovelessCodes/hono-better-auth)                      |
 
 ## UI
 
-| Name | Description | Link |
-|------|-------------|------|
+| Name             | Description                                           | Link                                                 |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------- |
 | `better-auth-ui` | Plug & play shadcn/ui auth components for better-auth | [Link](https://github.com/daveyplate/better-auth-ui) |
-
 
 ## Contributing
 
@@ -73,4 +73,3 @@ Open a PR to add to the list.
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-


### PR DESCRIPTION
I've added the expo-passkey plugin to the README. This plugin enables secure, passwordless authentication in Expo applications through native biometric authentication (Face ID, Touch ID, and fingerprint recognition). It provides a seamless integration between Better Auth's backend capabilities and Expo's client-side biometric functionality.
The plugin supports both iOS (16+) and Android (10+) and offers complete lifecycle management including registration, authentication, and revocation flows.