### PR TITLE
chore: mark better-auth-kit as archvied / replace tests package

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 |------|-------------|------|
 | `reverify` (archived) | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/reverify) |
 | `legal-consent` (archived) | A Legal Consent plugin for BetterAuth | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/legal-consent) |
-| `@better-auth-extended/test-utils` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://github.com/jslno/better-auth-extended/tree/main/packages/libraries/test-utils) |
-| `@better-auth-extended/app-invite` | Invite users to your application and allow them to sign up. | [Link](https://github.com/jslno/better-auth-extended/tree/main/packages/plugins/app-invite) |
+| `@better-auth-extended/test-utils` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://github.com/better-auth-extended/better-auth-extended/tree/main/packages/libraries/test-utils) |
+| `@better-auth-extended/app-invite` | Invite users to your application and allow them to sign up. | [Link](https://github.com/better-auth-extended/better-auth-extended/tree/main/packages/plugins/app-invite) |
 | `seed` (archived) | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/libraries/seed) |
 | `polar` | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth) |
 | `expo-passkey` | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey) |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 | `reverify` (archived) | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/reverify) |
 | `legal-consent` (archived) | A Legal Consent plugin for BetterAuth | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/legal-consent) |
 | `@better-auth-extended/test-utils` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://github.com/jslno/better-auth-extended/tree/main/packages/libraries/test-utils) |
-| `app-invite` | Invite users to your application and allow them to sign up. |
+| `@better-auth-extended/app-invite` | Invite users to your application and allow them to sign up. | [Link](https://github.com/jslno/better-auth-extended/tree/main/packages/plugins/app-invite) |
 | `seed` (archived) | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/libraries/seed) |
 | `polar` | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth) |
 | `expo-passkey` | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey) |

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 
 | Name | Description | Link |
 |------|-------------|------|
-| `convex` | Convex adapter for BetterAuth | [Link](https://www.better-auth-kit.com/docs/adapters/convex) |
+| `convex` (archived) | Convex adapter for BetterAuth | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/adapters/convex) |
 | `surreal` | SurrealDB adapter for BetterAuth | [Link](https://github.com/oskar-gmerek/surreal-better-auth/) |
 | `payload` | PayloadCMS adapter for BetterAuth | [Link](https://github.com/ForrestDevs/payload-better-auth/tree/main/packages/better-auth-db-adapter) |
 | `typeorm` | TypeORM adapter for BetterAuth | [Link](https://github.com/Zastinian/better-auth-typeorm) |
@@ -26,10 +26,11 @@ A curated list of awesome things related to <a href='https://github.com/better-a
 
 | Name | Description | Link |
 |------|-------------|------|
-| `reverify` | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://www.better-auth-kit.com/docs/plugins/reverify) |
-| `legal-consent` | A Legal Consent plugin for BetterAuth | [Link](https://www.better-auth-kit.com/docs/plugins/legal-consent) |
-| `@better-auth-kit/tests` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://www.better-auth-kit.com/docs/libraries/tests) |
-| `seed` | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://www.better-auth-kit.com/docs/cli/seed) |
+| `reverify` (archived) | Prompt the user to re-verify their identity by providing a form of authentication for revalidation | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/reverify) |
+| `legal-consent` (archived) | A Legal Consent plugin for BetterAuth | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/plugins/legal-consent) |
+| `@better-auth-extended/test-utils` | A collection of utilities to help you test your Better-Auth plugins | [Link](https://github.com/jslno/better-auth-extended/tree/main/packages/libraries/test-utils) |
+| `app-invite` | Invite users to your application and allow them to sign up. |
+| `seed` (archived) | Seed your Better-Auth database with deterministic, yet realistic, fake data to populate your database | [Link](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/libraries/seed) |
 | `polar` | A Better Auth plugin for integrating Polar payments and subscriptions into your authentication flow | [Link](https://docs.polar.sh/integrate/sdk/adapters/better-auth) |
 | `expo-passkey` | A Better Auth plugin enabling secure, passwordless authentication in Expo applications through native biometric authentication | [Link](https://github.com/iosazee/expo-passkey) |
 | `harmony` | A better-auth plugin for email & phone normalization and additional validation, blocking over 55,000 temporary email domains | [Link](https://github.com/GeKorm/better-auth-harmony) |


### PR DESCRIPTION
Marks [better-auth-kit](https://github.com/ping-maxwell/better-auth-kit) plugins as archived.
Replaces [`@better-auth-kit/tests`](https://github.com/ping-maxwell/better-auth-kit/tree/main/packages/libraries/tests) with [`@better-auth-extended/test-utils`](https://github.com/better-auth-extended/better-auth-extended/tree/main/packages/libraries/test-utils)
Added [`@better-auth-extended/app-invite`](https://github.com/better-auth-extended/better-auth-extended/tree/main/packages/plugins/app-invite)